### PR TITLE
[MAT-87] 팀 생성 API 리팩토링

### DIFF
--- a/src/main/java/com/matchus/domains/team/controller/TeamController.java
+++ b/src/main/java/com/matchus/domains/team/controller/TeamController.java
@@ -2,12 +2,15 @@ package com.matchus.domains.team.controller;
 
 import com.matchus.domains.team.dto.request.TeamCreateRequest;
 import com.matchus.domains.team.dto.request.TeamModifyRequest;
+import com.matchus.domains.team.dto.response.TeamCreateResponse;
 import com.matchus.domains.team.dto.response.TeamModifyResponse;
 import com.matchus.domains.team.service.TeamService;
+import com.matchus.global.jwt.JwtAuthentication;
 import com.matchus.global.response.ApiResponse;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,9 +30,14 @@ public class TeamController {
 		notes = "새로운 팀을 생성합니다."
 	)
 	@PostMapping
-	public ResponseEntity<Void> createTeam(@ModelAttribute TeamCreateRequest request) {
-		teamService.createTeam(request);
-		return ResponseEntity.ok().build();
+	public ResponseEntity<ApiResponse<TeamCreateResponse>> createTeam(
+		@ModelAttribute TeamCreateRequest request,
+		@AuthenticationPrincipal JwtAuthentication authentication
+	) {
+		String userEmail = authentication.username;
+		return ResponseEntity.ok(
+			ApiResponse.of(teamService.createTeam(request, userEmail))
+		);
 	}
 
 	@ApiOperation(

--- a/src/main/java/com/matchus/domains/team/dto/response/TeamCreateResponse.java
+++ b/src/main/java/com/matchus/domains/team/dto/response/TeamCreateResponse.java
@@ -1,5 +1,13 @@
 package com.matchus.domains.team.dto.response;
 
+import lombok.Getter;
+
+@Getter
 public class TeamCreateResponse {
 
+	private final Long teamId;
+
+	public TeamCreateResponse(Long teamId) {
+		this.teamId = teamId;
+	}
 }

--- a/src/test/java/com/matchus/domains/team/service/TeamServiceTest.java
+++ b/src/test/java/com/matchus/domains/team/service/TeamServiceTest.java
@@ -7,11 +7,17 @@ import com.matchus.domains.common.AgeGroup;
 import com.matchus.domains.sports.domain.Sports;
 import com.matchus.domains.sports.service.SportsService;
 import com.matchus.domains.team.converter.TeamConverter;
+import com.matchus.domains.team.domain.Grade;
 import com.matchus.domains.team.domain.Team;
+import com.matchus.domains.team.domain.TeamUser;
+import com.matchus.domains.team.dto.request.TeamCreateRequest;
 import com.matchus.domains.team.dto.request.TeamModifyRequest;
+import com.matchus.domains.team.dto.response.TeamCreateResponse;
 import com.matchus.domains.team.dto.response.TeamModifyResponse;
 import com.matchus.domains.team.repository.TeamRepository;
 import com.matchus.domains.team.repository.TeamUserRepository;
+import com.matchus.domains.user.domain.Gender;
+import com.matchus.domains.user.domain.User;
 import com.matchus.domains.user.repository.UserRepository;
 import com.matchus.global.service.FileUploadService;
 import java.util.Optional;
@@ -50,9 +56,69 @@ class TeamServiceTest {
 	@Mock
 	private UserRepository userRepository;
 
+	@DisplayName("팀 생성 서비스 성공 테스트")
+	@Test
+	void createTeamTest() {
+		MockMultipartFile file = new MockMultipartFile(
+			"file", "originalFilename", "multipart/form-data", "file".getBytes()
+		);
+		String teamName = "팀이름";
+		String bio = "팀소개";
+		String sports = "축구";
+		String ageGroup = "20대";
+		TeamCreateRequest request = new TeamCreateRequest(file, teamName, bio, sports, ageGroup);
+		Sports sport = new Sports(1L, "축구");
+		String logo = "팀로고.jpg";
+		String email = "이메일@email.com";
+		User user = User
+			.builder()
+			.id(1L)
+			.sport(sport)
+			.email(email)
+			.name("이름")
+			.password("비밀번호")
+			.nickname("닉네임")
+			.gender(Gender.MAN)
+			.ageGroup(AgeGroup.TWENTIES)
+			.build();
+		Team team = Team
+			.builder()
+			.id(1L)
+			.sport(sport)
+			.name(teamName)
+			.bio(bio)
+			.logo(logo)
+			.ageGroup(AgeGroup.TWENTIES)
+			.build();
+		TeamUser teamUser = TeamUser
+			.builder()
+			.team(team)
+			.user(user)
+			.grade(Grade.CAPTAIN)
+			.build();
+		given(sportsService.getSports(any())).willReturn(sport);
+		given(uploadService.uploadImage(any())).willReturn(logo);
+		given(userRepository.findByEmailAndIsDisaffiliatedFalse(any())).willReturn(Optional.of(user));
+		given(teamConverter.convertToTeam(any(), any(), any())).willReturn(team);
+		given(teamRepository.save(any())).willReturn(team);
+		given(teamUserRepository.save(any())).willReturn(teamUser);
+
+		// when
+		TeamCreateResponse response = teamService.createTeam(request, email);
+
+		// then
+		assertThat(response.getTeamId()).isEqualTo(1L);
+
+		verify(sportsService, times(1)).getSports(any());
+		verify(uploadService, times(1)).uploadImage(any());
+		verify(teamConverter, times(1)).convertToTeam(any(), any(), any());
+		verify(teamRepository, times(1)).save(any());
+		verify(teamUserRepository, times(1)).save(any());
+	}
+
 	@DisplayName("팀 정보 수정 서비스 성공 테스트")
 	@Test
-	void modifyTeam() {
+	void modifyTeamTest() {
 		// given
 		Long teamId = 1L;
 		String logo = "modifiedImage.jpg";


### PR DESCRIPTION
## 작업 사항

- 팀 생성 API 컨트롤러에서 JWT로부터 유저 정보를 추출하고, 유저 정보를 이용한 기능 구현
- 생성된 Team의 id(식별자)를 응답 데이터로 보내줌
- 팀 생성 Service 테스트 코드 작성

