### PR TITLE
[MAT-131]  필터를 사용한 매치 리스트 조회 api 구현

### DIFF
--- a/src/main/java/com/matchus/domains/match/controller/MatchController.java
+++ b/src/main/java/com/matchus/domains/match/controller/MatchController.java
@@ -1,13 +1,17 @@
 package com.matchus.domains.match.controller;
 
 import com.matchus.domains.match.dto.request.MatchCreateRequest;
+import com.matchus.domains.match.dto.request.MatchRetrieveFilterRequest;
 import com.matchus.domains.match.dto.response.MatchCreateResponse;
 import com.matchus.domains.match.dto.response.MatchInfoResponse;
+import com.matchus.domains.match.dto.response.MatchRetrieveByFilterResponse;
 import com.matchus.domains.match.service.MatchService;
 import com.matchus.global.response.ApiResponse;
+import com.matchus.global.utils.PageRequest;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,6 +44,22 @@ public class MatchController {
 	@GetMapping("/{matchId}")
 	public ResponseEntity<ApiResponse<MatchInfoResponse>> getMatchInfo(@PathVariable Long matchId) {
 		return ResponseEntity.ok(ApiResponse.of(matchService.getMatchInfo(matchId)));
+	}
+
+	@ApiOperation(
+		value = "매치 게시글 리스트 필터 조회",
+		notes = "매치 게시글 리스트를 조회합니다. 필터를 설정하여 조회할 수 있습니다."
+	)
+	@GetMapping
+	public ResponseEntity<ApiResponse<MatchRetrieveByFilterResponse>> retrieveMatches(
+		@ModelAttribute MatchRetrieveFilterRequest filterRequest,
+		PageRequest pageRequest
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.of(
+				matchService.retrieveMatchNoOffsetByFilter(filterRequest, pageRequest)
+			)
+		);
 	}
 
 }

--- a/src/main/java/com/matchus/domains/match/domain/Match.java
+++ b/src/main/java/com/matchus/domains/match/domain/Match.java
@@ -126,7 +126,7 @@ public class Match extends BaseEntity {
 		this.detail = detail;
 	}
 
-	public void modifyStatus(MatchStatus matchStatus) {
+	public void changeStatus(MatchStatus matchStatus) {
 		this.status = matchStatus;
 	}
 

--- a/src/main/java/com/matchus/domains/match/dto/request/MatchRetrieveFilterRequest.java
+++ b/src/main/java/com/matchus/domains/match/dto/request/MatchRetrieveFilterRequest.java
@@ -1,0 +1,44 @@
+package com.matchus.domains.match.dto.request;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@Setter
+public class MatchRetrieveFilterRequest {
+
+	private String sports;
+
+	private String ageGroup;
+
+	private Long cityId;
+
+	private Long regionId;
+
+	private Long groundId;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate date;
+
+	public MatchRetrieveFilterRequest() {
+	}
+
+	public MatchRetrieveFilterRequest(
+		String sports,
+		String ageGroup,
+		Long cityId,
+		Long regionId,
+		Long groundId,
+		LocalDate date
+	) {
+		this.sports = sports;
+		this.ageGroup = ageGroup;
+		this.cityId = cityId;
+		this.regionId = regionId;
+		this.groundId = groundId;
+		this.date = date;
+	}
+
+}

--- a/src/main/java/com/matchus/domains/match/dto/response/MatchListByFilterResponse.java
+++ b/src/main/java/com/matchus/domains/match/dto/response/MatchListByFilterResponse.java
@@ -1,0 +1,40 @@
+package com.matchus.domains.match.dto.response;
+
+import com.matchus.domains.common.AgeGroup;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MatchListByFilterResponse {
+
+	private final Long matchId;
+
+	private final String city;
+
+	private final String region;
+
+	private final String ground;
+
+	private final LocalDate date;
+
+	private final LocalTime startTime;
+
+	private final LocalTime endTime;
+
+	private final AgeGroup ageGroup;
+
+	private final String sports;
+
+	private final Long teamId;
+
+	private final String teamLogo;
+
+	private final String teamName;
+
+	private final BigDecimal teamMannerTemperature;
+
+}

--- a/src/main/java/com/matchus/domains/match/dto/response/MatchRetrieveByFilterResponse.java
+++ b/src/main/java/com/matchus/domains/match/dto/response/MatchRetrieveByFilterResponse.java
@@ -1,0 +1,15 @@
+package com.matchus.domains.match.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MatchRetrieveByFilterResponse {
+
+	private final List<MatchListByFilterResponse> matchList;
+
+	public MatchRetrieveByFilterResponse(List<MatchListByFilterResponse> matchList) {
+		this.matchList = matchList;
+	}
+
+}

--- a/src/main/java/com/matchus/domains/match/repository/MatchRepository.java
+++ b/src/main/java/com/matchus/domains/match/repository/MatchRepository.java
@@ -3,6 +3,6 @@ package com.matchus.domains.match.repository;
 import com.matchus.domains.match.domain.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MatchRepository extends JpaRepository<Match, Long> {
+public interface MatchRepository extends JpaRepository<Match, Long>, MatchRepositoryCustom {
 
 }

--- a/src/main/java/com/matchus/domains/match/repository/MatchRepositoryCustom.java
+++ b/src/main/java/com/matchus/domains/match/repository/MatchRepositoryCustom.java
@@ -1,0 +1,21 @@
+package com.matchus.domains.match.repository;
+
+import com.matchus.domains.common.AgeGroup;
+import com.matchus.domains.match.dto.response.MatchListByFilterResponse;
+import com.matchus.global.utils.PageRequest;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MatchRepositoryCustom {
+
+	List<MatchListByFilterResponse> findAllNoOffsetByFilter(
+		Long sportsId,
+		AgeGroup ageGroup,
+		Long cityId,
+		Long regionId,
+		Long groundId,
+		LocalDate date,
+		PageRequest pageRequest
+	);
+
+}

--- a/src/main/java/com/matchus/domains/match/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/matchus/domains/match/repository/MatchRepositoryImpl.java
@@ -1,0 +1,125 @@
+package com.matchus.domains.match.repository;
+
+import static com.matchus.domains.location.domain.QCity.*;
+import static com.matchus.domains.location.domain.QGround.*;
+import static com.matchus.domains.location.domain.QRegion.*;
+import static com.matchus.domains.match.domain.QMatch.*;
+import static com.matchus.domains.sports.domain.QSports.*;
+import static com.matchus.domains.team.domain.QTeam.*;
+
+import com.matchus.domains.common.AgeGroup;
+import com.matchus.domains.match.dto.response.MatchListByFilterResponse;
+import com.matchus.global.utils.PageRequest;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+
+public class MatchRepositoryImpl implements MatchRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	public MatchRepositoryImpl(JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public List<MatchListByFilterResponse> findAllNoOffsetByFilter(
+		Long sportsId,
+		AgeGroup ageGroup,
+		Long cityId,
+		Long regionId,
+		Long groundId,
+		LocalDate date,
+		PageRequest pageRequest
+	) {
+		return queryFactory
+			.select(
+				Projections.constructor(
+					MatchListByFilterResponse.class,
+					match.id.as("matchId"),
+					match.city.name.as("city"),
+					match.region.name.as("region"),
+					match.ground.name.as("ground"),
+					match.period.date.as("date"),
+					match.period.startTime.as("startTime"),
+					match.period.endTime.as("endTime"),
+					match.ageGroup.as("ageGroup"),
+					match.sport.name.as("sports"),
+					team.id.as("teamId"),
+					team.logo.as("teamLogo"),
+					team.name.as("teamName"),
+					team.mannerTemperature.as("teamMannerTemperature")
+				)
+			)
+			.from(match)
+			.join(match.homeTeam, team)
+			.join(match.city, city)
+			.join(match.region, region)
+			.join(match.ground, ground)
+			.join(match.sport, sports)
+			.where(
+				ltMatchId(pageRequest.getLastId()),
+				eqSports(sportsId),
+				eqAgeGroup(ageGroup),
+				eqCity(cityId),
+				eqRegion(regionId),
+				eqGround(groundId),
+				eqDate(date)
+			)
+			.orderBy(match.id.desc())
+			.limit(pageRequest.getSize())
+			.fetch();
+	}
+
+	private BooleanExpression ltMatchId(Long matchId) {
+		if (matchId == null) {
+			return null;
+		}
+		return match.id.lt(matchId);
+	}
+
+	private BooleanExpression eqSports(Long sports) {
+		if (sports == null) {
+			return null;
+		}
+		return match.sport.id.eq(sports);
+	}
+
+	private BooleanExpression eqAgeGroup(AgeGroup ageGroup) {
+		if (ageGroup == null) {
+			return null;
+		}
+		return match.ageGroup.eq(ageGroup);
+	}
+
+	private BooleanExpression eqCity(Long cityId) {
+		if (cityId == null) {
+			return null;
+		}
+		return city.id.eq(cityId);
+	}
+
+	private BooleanExpression eqRegion(Long regionId) {
+		if (regionId == null) {
+			return null;
+		}
+		return region.id.eq(regionId);
+	}
+
+	private BooleanExpression eqGround(Long groundId) {
+		if (groundId == null) {
+			return null;
+		}
+		return ground.id.eq(groundId);
+	}
+
+	private BooleanExpression eqDate(LocalDate date) {
+		if (date == null) {
+			return null;
+		}
+		return match.period.date.eq(date);
+	}
+
+}

--- a/src/main/java/com/matchus/domains/match/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/matchus/domains/match/repository/MatchRepositoryImpl.java
@@ -8,6 +8,7 @@ import static com.matchus.domains.sports.domain.QSports.*;
 import static com.matchus.domains.team.domain.QTeam.*;
 
 import com.matchus.domains.common.AgeGroup;
+import com.matchus.domains.match.domain.MatchStatus;
 import com.matchus.domains.match.dto.response.MatchListByFilterResponse;
 import com.matchus.global.utils.PageRequest;
 import com.querydsl.core.types.Projections;
@@ -66,7 +67,8 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
 				eqCity(cityId),
 				eqRegion(regionId),
 				eqGround(groundId),
-				eqDate(date)
+				eqDate(date),
+				match.status.eq(MatchStatus.WAITING)
 			)
 			.orderBy(match.id.desc())
 			.limit(pageRequest.getSize())

--- a/src/main/java/com/matchus/domains/match/service/MatchService.java
+++ b/src/main/java/com/matchus/domains/match/service/MatchService.java
@@ -1,5 +1,6 @@
 package com.matchus.domains.match.service;
 
+import com.matchus.domains.common.AgeGroup;
 import com.matchus.domains.location.domain.Location;
 import com.matchus.domains.location.service.LocationService;
 import com.matchus.domains.match.converter.MatchConverter;
@@ -7,9 +8,12 @@ import com.matchus.domains.match.domain.Match;
 import com.matchus.domains.match.domain.TeamWaiting;
 import com.matchus.domains.match.domain.WaitingType;
 import com.matchus.domains.match.dto.request.MatchCreateRequest;
+import com.matchus.domains.match.dto.request.MatchRetrieveFilterRequest;
 import com.matchus.domains.match.dto.response.MatchCreateResponse;
 import com.matchus.domains.match.dto.response.MatchInfoResponse;
+import com.matchus.domains.match.dto.response.MatchListByFilterResponse;
 import com.matchus.domains.match.dto.response.MatchMember;
+import com.matchus.domains.match.dto.response.MatchRetrieveByFilterResponse;
 import com.matchus.domains.match.exception.MatchNotFoundException;
 import com.matchus.domains.match.repository.MatchRepository;
 import com.matchus.domains.sports.domain.Sports;
@@ -20,6 +24,7 @@ import com.matchus.domains.team.exception.TeamUserNotFoundException;
 import com.matchus.domains.team.service.TeamService;
 import com.matchus.domains.user.domain.User;
 import com.matchus.global.error.ErrorCode;
+import com.matchus.global.utils.PageRequest;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -81,6 +86,27 @@ public class MatchService {
 					match, regiserTeamInfo, buildTeamInfoResponse(match, WaitingType.SELECTED));
 		}
 	}
+
+	public MatchRetrieveByFilterResponse retrieveMatchNoOffsetByFilter(
+		MatchRetrieveFilterRequest filterRequest,
+		PageRequest pageRequest
+	) {
+		Sports sports = sportsService.getSportsOrNull(filterRequest.getSports());
+		AgeGroup ageGroup = AgeGroup.findGroupOrNull(filterRequest.getAgeGroup());
+
+		List<MatchListByFilterResponse> matchs = matchRepository.findAllNoOffsetByFilter(
+			sports == null ? null : sports.getId(),
+			ageGroup,
+			filterRequest.getCityId(),
+			filterRequest.getRegionId(),
+			filterRequest.getGroundId(),
+			filterRequest.getDate() == null ? null : filterRequest.getDate(),
+			pageRequest
+		);
+
+		return new MatchRetrieveByFilterResponse(matchs);
+	}
+
 
 	public Match findExistingMatch(Long matchId) {
 		return matchRepository


### PR DESCRIPTION
## 작업 사항

- 깔아주신 꽃길 따라 구현 하였습니다!
- 필터를 사용한 매치 리스트 조회 api 구현
- 필터가 없을 경우 매치 전체 리스트 조회

## 중점 사항

- Response dto의 경우 @Getter 를 사용하여 역직렬화 되는 것 확인했습니다!
