### PR TITLE
[MAT-255] cors 에러 해결

### DIFF
--- a/src/main/java/com/matchus/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/matchus/global/config/WebSecurityConfig.java
@@ -119,7 +119,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 
-		configuration.addAllowedOrigin("*");
+		configuration.addAllowedOriginPattern("*");
 		configuration.addAllowedHeader("*");
 		configuration.addAllowedMethod("*");
 		configuration.setAllowCredentials(true);


### PR DESCRIPTION
## 작업 사항

- cors 에러 해결 : setAllowCredentials 와 기존의 addAllowedOrigin은 같이 사용할 수 없다고 합니다.

## 중점 사항

- 
