### PR TITLE
[MAT-260] 팀 매칭 조회 Response 수정

### DIFF
--- a/src/main/java/com/matchus/domains/team/service/TeamService.java
+++ b/src/main/java/com/matchus/domains/team/service/TeamService.java
@@ -49,6 +49,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TeamService {
 
+	public static final String EMPTY_STRING = "";
+
 	private final TeamConverter teamConverter;
 	private final TeamRepository teamRepository;
 	private final SportsService sportsService;
@@ -187,10 +189,10 @@ public class TeamService {
 						.getId() : null,
 					match.getAwayTeam() != null ? match
 						.getAwayTeam()
-						.getName() : null,
+						.getName() : EMPTY_STRING,
 					match.getAwayTeam() != null ? match
 						.getAwayTeam()
-						.getLogo() : null,
+						.getLogo() : EMPTY_STRING,
 					match
 						.getPeriod()
 						.getDate(),


### PR DESCRIPTION
## 작업 사항

- 팀 매칭 조회 Response 데이터 중 ApplyTeam이 존재하지 않을 때 팀이름, 팀로고가 null이었던 것을 `빈 문자열("")`로 수정

## 중점 사항

- 
